### PR TITLE
Remove the version from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "adapter-responsive-video",
-  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Like in [AMP for WordPress](https://github.com/automattic/amp-wp), this version doesn't seem to be needed.