### PR TITLE
Trigger a `1.1.1` release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ workflows:
     jobs:
       - wp-svn/deploy:
           context: kienstra-svn
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
       - approval-for-deploy-tested-up-to-bump:
           type: approval
           filters:


### PR DESCRIPTION
* The 1.1.1 deployment [failed](https://app.circleci.com/pipelines/github/kienstra/adapter-responsive-video/42/workflows/612cec99-2d95-4570-97e9-279e530b24aa/jobs/43) because I forgot to cd into the tmp directory where the SVN repo was
* It looks like you can't re-trigger a release build, while getting the latest from the orb
* So trigger it here